### PR TITLE
Update for ISLE 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,21 +122,21 @@ This is the anatomy of multi-env (**nb:** this section only a explanation of the
 
 **Development Environment**  
 * Islandora is available at http://dev.isle.localdomain
-* Fedora is available at http://localhost:8380/
-* Solr is available at http://localhost:8381/
-* ImageServices are available at http://localhost:8382/
-
-**Staging Environment**  
-* Islandora is available at http://stage.isle.localdomain
 * Fedora is available at http://localhost:8280/
 * Solr is available at http://localhost:8281/
 * ImageServices are available at http://localhost:8282/
 
-**Production Environment**  
-* Islandora is available at http://isle.localdomain
+**Staging Environment**  
+* Islandora is available at http://stage.isle.localdomain
 * Fedora is available at http://localhost:8180/
 * Solr is available at http://localhost:8181/
 * ImageServices are available at http://localhost:8182/
+
+**Production Environment**  
+* Islandora is available at http://isle.localdomain
+* Fedora is available at http://localhost:8080/
+* Solr is available at http://localhost:8081/
+* ImageServices are available at http://localhost:8082/
 
 ### Users and Passwords
 Read as username:password

--- a/dev/.env
+++ b/dev/.env
@@ -1,40 +1,169 @@
 COMPOSE_PROJECT_NAME=isle-dev
-
 CONTAINER_SHORT_ID=dev
 
 BASE_DOMAIN=dev.isle.localdomain
 
 ISLE_PROXY_NAME=isle-proxy
 
-##################################
-## STOP EDITING!
-## THIS IS NOT YET IMPLEMENTED
-## CONFD will make magic happen.
+## Edit these to configure this instance:
 
-## Database (SQL)
+### MySQL root password
 MYSQL_ROOT_PASSWORD=ild_mysqlrt_2018
 
-## Islandora (DRUPAL)
-ADMIN_USER=isle
-ADMIN_USER_PASS=isle
-ADMIN_EMAIL=admin@isle.localdomain
-DRUPAL_SITE_NAME=ISLE.localdomain
-DRUPAL_DB=isle_ld
-DRUPAL_DB_USER=isle_ld_user
-DRUPAL_DB_PASS=isle_ld_db2018
+### Fedora database name
+FEDORA_DB=fedora3
 
-## Tomcat Instances (applies to all)
-TOMCAT_ADMIN_USER=admin
-TOMCAT_ADMIN_PASS=isle_admin
-TOMCAT_MANAGER_USER=manager
-TOMCAT_MANAGER_PASS=isle_manager
-
-## Fedora Repo
-FEDORA_ADMIN_USER=fedoraAdmin
-FEDORA_ADMIN_PASS=ild_fed_admin_2018
+### Fedora database user
 FEDORA_DB_USER=fedora_admin
+
+### Fedora database password 
 FEDORA_DB_PASS=ild_feddb_2018
 
-## Fedora GSearch
-FEDORA_GSEARCH_USER=fgsAdmin 
+### Drupal database name
+DRUPAL_DB=isle_ld 
+
+### Drupal database user
+DRUPAL_DB_USER=isle_ld_user
+
+### Drupal database password
+DRUPAL_DB_PASS=isle_ld_db2018
+
+## Database (SQL) end.
+
+
+## Islandora (DRUPAL)
+
+### Site name 
+DRUPAL_SITE_NAME=ISLE.localdomain
+
+### Site administrator user 
+DRUPAL_ADMIN_USER=isle
+
+### Site administrator password 
+DRUPAL_ADMIN_PASS=isle
+
+### Site administrator email 
+DRUPAL_ADMIN_EMAIL=admin@isle.localdomain
+
+### Hash Salt, a long unique alpha-numeric (i.e., no special characters). Suggested length greater than 40 characters. 
+DRUPAL_HASH_SALT=YO9ST25G4zaVnJT7w05PEH3r39pxhQQUf0LMo6NztY9al
+
+## End Islandora
+
+
+## Fedora Repository 
+
+### Fedora administrator user 
+FEDORA_ADMIN_USER=fedoraAdmin
+
+### Fedora administrator password 
+FEDORA_ADMIN_PASS=ild_fed_admin_2018
+
+### Fedora Generic Search user 
+FEDORA_GSEARCH_USER=fgsAdmin
+
+### Fedora Generic Search pass 
 FEDORA_GSEARCH_PASS=ild_fgs_admin_2018
+
+### Fedora internal call user 
+FEDORA_INTCALL_USER=fedoraIntCallUser
+
+### Fedora internal call password 
+FEDORA_INTCALL_PASS=ild_fed_IntCallUser_2018
+
+## End Fedora Repository
+
+
+## Image Services
+
+### Enable the Cantaloupe IIIF image service admin interface
+## Acceptable values: "true" or "false"
+CANTALOUPE_ADMIN_INTERFACE_ENABLE=true
+
+### Admin Username and Password
+CANTALOUPE_ADMIN_USER=admin
+CANTALOUPE_ADMIN_PASS=isle_admin
+
+## End Image Services
+
+
+## Database (SQL)
+
+### MySQL root password
+MYSQL_ROOT_PASSWORD=ild_mysqlrt_2018
+
+### Fedora database name
+FEDORA_DB=fedora3
+
+### Fedora database user
+FEDORA_DB_USER=fedora_admin
+
+### Fedora database password 
+FEDORA_DB_PASS=ild_feddb_2018
+
+### Drupal database name
+DRUPAL_DB=isle_ld 
+
+### Drupal database user
+DRUPAL_DB_USER=isle_ld_user
+
+### Drupal database password
+DRUPAL_DB_PASS=isle_ld_db2018
+
+## Database (SQL) end.
+
+
+## Islandora (DRUPAL)
+
+### Site name 
+DRUPAL_SITE_NAME=ISLE.localdomain
+
+### Site administrator user 
+DRUPAL_ADMIN_USER=isle
+
+### Site administrator password 
+DRUPAL_ADMIN_PASS=isle
+
+### Site administrator email 
+DRUPAL_ADMIN_EMAIL=admin@isle.localdomain
+
+### Hash Salt, a long unique alpha-numeric (i.e., no special characters). Suggested length greater than 40 characters. 
+DRUPAL_HASH_SALT=YO9ST25G4zaVnJT7w05PEH3r39pxhQQUf0LMo6NztY9al
+
+## End Islandora
+
+
+## Fedora Repository 
+
+### Fedora administrator user 
+FEDORA_ADMIN_USER=fedoraAdmin
+
+### Fedora administrator password 
+FEDORA_ADMIN_PASS=ild_fed_admin_2018
+
+### Fedora Generic Search user 
+FEDORA_GSEARCH_USER=fgsAdmin
+
+### Fedora Generic Search pass 
+FEDORA_GSEARCH_PASS=ild_fgs_admin_2018
+
+### Fedora internal call user 
+FEDORA_INTCALL_USER=fedoraIntCallUser
+
+### Fedora internal call password 
+FEDORA_INTCALL_PASS=ild_fed_IntCallUser_2018
+
+## End Fedora Repository
+
+
+## Image Services
+
+### Enable the Cantaloupe IIIF image service admin interface
+## Acceptable values: "true" or "false"
+CANTALOUPE_ADMIN_INTERFACE_ENABLE=true
+
+### Admin Username and Password
+CANTALOUPE_ADMIN_USER=admin
+CANTALOUPE_ADMIN_PASS=isle_admin
+
+## End Image Services

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       - mysql
       - fedora
       - solr
-      - traefik
     volumes:
       - isle-apache-data:/var/www/html
       - ./logs/apache/httpd:/var/log/apache2

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -2,71 +2,85 @@ version: '3'
 
 services:
   mysql:
-    image: islandoracollabgroup/isle-mysql:latest
+    image: islandoracollabgroup/isle-mysql:1.1
     container_name: isle-mysql-${CONTAINER_SHORT_ID}
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD
     networks:
-      isle-internal:
+      - isle-internal
     volumes:
       - isle-db-data:/var/lib/mysql
       - ./logs/mysql:/var/log/mysql
 
   fedora:
-    image: benjaminrosner/isle-fedora:latest
+    image: islandoracollabgroup/isle-fedora:1.1
     container_name: isle-fedora-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=768M  ## Tweak to desired
+      - JAVA_MIN_MEM=128M  ## Tweak to desired
+    env_file: 
+      - tomcat.env
+      - .env
     networks:
-      isle-internal:
+      - isle-internal
     ports:
-      - "8380:8080"
+      - "8280:8080"
     depends_on:
       - mysql
       - solr
-    environment:
-      - JAVA_MAX_MEM=512M
-      - JAVA_MIN_MEM=0
     volumes:
-      - isle-fedora-data:/usr/local/fedora/data
+      - isle-fedora-datastreamStore:/usr/local/fedora/data/datastreamStore # Migrators change this to your local DS folder.
+      - isle-fedora-objectStore:/usr/local/fedora/data/objectStore # Migrators change this to your local OS folder.
+      - isle-fedora-resourceIndex:/usr/local/fedora/data/resourceIndex # Migrators change this to your local RI folder.
+      - isle-fedora-activemq:/usr/local/fedora/data/activemq-data # Migrators change this to your local MQ folder.
+      - isle-fedora-XACML:/usr/local/fedora/data/fedora-xacml-policies
       - ./logs/fedora/fcrepo:/usr/local/fedora/server/logs
       - ./logs/fedora/tomcat:/usr/local/tomcat/logs
 
   solr:
-    image: benjaminrosner/isle-solr:latest
+    image: islandoracollabgroup/isle-solr:1.1
     container_name: isle-solr-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=512M  ## Tweak to desired
+      - JAVA_MIN_MEM=0  ## Tweak to desired
+    env_file:
+      - tomcat.env
     networks:
-      isle-internal:
+      - isle-internal
     ports:
-      - "8381:8080"
+      - "8281:8080"
     depends_on:
       - mysql
-    environment:
-      - JAVA_MAX_MEM=512M
-      - JAVA_MIN_MEM=0
     volumes:
       - isle-solr-data:/usr/local/solr
       - ./logs/solr:/usr/local/tomcat/logs
-      
+
   image-services:
-    image: benjaminrosner/isle-imageservices:latest
+    image: islandoracollabgroup/isle-imageservices:1.1
     container_name: isle-images-${CONTAINER_SHORT_ID}
-    networks:
-      isle-internal:
-    ports:
-      - "8382:8080"
-    depends_on:
-      - apache
-      - fedora
     environment:
       - JAVA_MAX_MEM=512M
       - JAVA_MIN_MEM=0
+    env_file: 
+      - tomcat.env
+      - .env
+    networks:
+      - isle-internal
+    depends_on:
+      - apache
+      - fedora
+    ports:
+      - "8282:8080"
     volumes:
       - ./logs/imageservices:/usr/local/tomcat/logs
 
   apache:
-    image: benjaminrosner/isle-apache:latest
+    image: islandoracollabgroup/isle-apache:1.1
     container_name: isle-apache-${CONTAINER_SHORT_ID}
     environment:
       - PULL_ISLE_BUILD_TOOLS=true # Defaults to true.
+    env_file: 
+      - .env
     networks:
       isle-internal:
         aliases:
@@ -76,15 +90,16 @@ services:
       - mysql
       - fedora
       - solr
+      - traefik
     volumes:
       - isle-apache-data:/var/www/html
       - ./logs/apache/httpd:/var/log/apache2
       - ./logs/apache/fits:/var/log/fits
     labels:
-      - traefik.backend=isle-apache-${CONTAINER_SHORT_ID}
-      - traefik.docker.network=${ISLE_PROXY_NAME}
+      - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
       - traefik.enable=true
-      - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /fedora, /solr, /adore-djatoka, /cantaloupe, /iiif"
+      - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
+
 
 # Defined networks
 networks:
@@ -93,8 +108,13 @@ networks:
     external:
       name: ${ISLE_PROXY_NAME}
 
+# Docker controlled volumes. 
 volumes:
   isle-db-data:
-  isle-fedora-data:
+  isle-fedora-datastreamStore:
+  isle-fedora-objectStore:
+  isle-fedora-resourceIndex:
+  isle-fedora-activemq:
+  isle-fedora-XACML:
   isle-solr-data:
   isle-apache-data:

--- a/dev/tomcat.env
+++ b/dev/tomcat.env
@@ -1,0 +1,8 @@
+## Tomcat Instances (This applies to the Fedora, Solr, and ImageService containers)
+
+TOMCAT_ADMIN_USER=admin
+TOMCAT_ADMIN_PASS=isle_admin
+TOMCAT_MANAGER_USER=manager
+TOMCAT_MANAGER_PASS=isle_manager
+
+## End Tomcat

--- a/prod/.env
+++ b/prod/.env
@@ -1,40 +1,169 @@
-COMPOSE_PROJECT_NAME=isle-production
-
+COMPOSE_PROJECT_NAME=isle-prod
 CONTAINER_SHORT_ID=prod
 
 BASE_DOMAIN=isle.localdomain
 
 ISLE_PROXY_NAME=isle-proxy
 
-##################################
-## STOP EDITING!
-## THIS IS NOT YET IMPLEMENTED
-## CONFD will make magic happen.
+## Edit these to configure this instance:
 
-## Database (SQL)
+### MySQL root password
 MYSQL_ROOT_PASSWORD=ild_mysqlrt_2018
 
-## Islandora (DRUPAL)
-ADMIN_USER=isle
-ADMIN_USER_PASS=isle
-ADMIN_EMAIL=admin@isle.localdomain
-DRUPAL_SITE_NAME=ISLE.localdomain
-DRUPAL_DB=isle_ld
-DRUPAL_DB_USER=isle_ld_user
-DRUPAL_DB_PASS=isle_ld_db2018
+### Fedora database name
+FEDORA_DB=fedora3
 
-## Tomcat Instances (applies to all)
-TOMCAT_ADMIN_USER=admin
-TOMCAT_ADMIN_PASS=isle_admin
-TOMCAT_MANAGER_USER=manager
-TOMCAT_MANAGER_PASS=isle_manager
-
-## Fedora Repo
-FEDORA_ADMIN_USER=fedoraAdmin
-FEDORA_ADMIN_PASS=ild_fed_admin_2018
+### Fedora database user
 FEDORA_DB_USER=fedora_admin
+
+### Fedora database password 
 FEDORA_DB_PASS=ild_feddb_2018
 
-## Fedora GSearch
-FEDORA_GSEARCH_USER=fgsAdmin 
+### Drupal database name
+DRUPAL_DB=isle_ld 
+
+### Drupal database user
+DRUPAL_DB_USER=isle_ld_user
+
+### Drupal database password
+DRUPAL_DB_PASS=isle_ld_db2018
+
+## Database (SQL) end.
+
+
+## Islandora (DRUPAL)
+
+### Site name 
+DRUPAL_SITE_NAME=ISLE.localdomain
+
+### Site administrator user 
+DRUPAL_ADMIN_USER=isle
+
+### Site administrator password 
+DRUPAL_ADMIN_PASS=isle
+
+### Site administrator email 
+DRUPAL_ADMIN_EMAIL=admin@isle.localdomain
+
+### Hash Salt, a long unique alpha-numeric (i.e., no special characters). Suggested length greater than 40 characters. 
+DRUPAL_HASH_SALT=YO9ST25G4zaVnJT7w05PEH3r39pxhQQUf0LMo6NztY9al
+
+## End Islandora
+
+
+## Fedora Repository 
+
+### Fedora administrator user 
+FEDORA_ADMIN_USER=fedoraAdmin
+
+### Fedora administrator password 
+FEDORA_ADMIN_PASS=ild_fed_admin_2018
+
+### Fedora Generic Search user 
+FEDORA_GSEARCH_USER=fgsAdmin
+
+### Fedora Generic Search pass 
 FEDORA_GSEARCH_PASS=ild_fgs_admin_2018
+
+### Fedora internal call user 
+FEDORA_INTCALL_USER=fedoraIntCallUser
+
+### Fedora internal call password 
+FEDORA_INTCALL_PASS=ild_fed_IntCallUser_2018
+
+## End Fedora Repository
+
+
+## Image Services
+
+### Enable the Cantaloupe IIIF image service admin interface
+## Acceptable values: "true" or "false"
+CANTALOUPE_ADMIN_INTERFACE_ENABLE=true
+
+### Admin Username and Password
+CANTALOUPE_ADMIN_USER=admin
+CANTALOUPE_ADMIN_PASS=isle_admin
+
+## End Image Services
+
+
+## Database (SQL)
+
+### MySQL root password
+MYSQL_ROOT_PASSWORD=ild_mysqlrt_2018
+
+### Fedora database name
+FEDORA_DB=fedora3
+
+### Fedora database user
+FEDORA_DB_USER=fedora_admin
+
+### Fedora database password 
+FEDORA_DB_PASS=ild_feddb_2018
+
+### Drupal database name
+DRUPAL_DB=isle_ld 
+
+### Drupal database user
+DRUPAL_DB_USER=isle_ld_user
+
+### Drupal database password
+DRUPAL_DB_PASS=isle_ld_db2018
+
+## Database (SQL) end.
+
+
+## Islandora (DRUPAL)
+
+### Site name 
+DRUPAL_SITE_NAME=ISLE.localdomain
+
+### Site administrator user 
+DRUPAL_ADMIN_USER=isle
+
+### Site administrator password 
+DRUPAL_ADMIN_PASS=isle
+
+### Site administrator email 
+DRUPAL_ADMIN_EMAIL=admin@isle.localdomain
+
+### Hash Salt, a long unique alpha-numeric (i.e., no special characters). Suggested length greater than 40 characters. 
+DRUPAL_HASH_SALT=YO9ST25G4zaVnJT7w05PEH3r39pxhQQUf0LMo6NztY9al
+
+## End Islandora
+
+
+## Fedora Repository 
+
+### Fedora administrator user 
+FEDORA_ADMIN_USER=fedoraAdmin
+
+### Fedora administrator password 
+FEDORA_ADMIN_PASS=ild_fed_admin_2018
+
+### Fedora Generic Search user 
+FEDORA_GSEARCH_USER=fgsAdmin
+
+### Fedora Generic Search pass 
+FEDORA_GSEARCH_PASS=ild_fgs_admin_2018
+
+### Fedora internal call user 
+FEDORA_INTCALL_USER=fedoraIntCallUser
+
+### Fedora internal call password 
+FEDORA_INTCALL_PASS=ild_fed_IntCallUser_2018
+
+## End Fedora Repository
+
+
+## Image Services
+
+### Enable the Cantaloupe IIIF image service admin interface
+## Acceptable values: "true" or "false"
+CANTALOUPE_ADMIN_INTERFACE_ENABLE=true
+
+### Admin Username and Password
+CANTALOUPE_ADMIN_USER=admin
+CANTALOUPE_ADMIN_PASS=isle_admin
+
+## End Image Services

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       - mysql
       - fedora
       - solr
-      - traefik
     volumes:
       - isle-apache-data:/var/www/html
       - ./logs/apache/httpd:/var/log/apache2

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -2,71 +2,85 @@ version: '3'
 
 services:
   mysql:
-    image: islandoracollabgroup/isle-mysql:latest
+    image: islandoracollabgroup/isle-mysql:1.1
     container_name: isle-mysql-${CONTAINER_SHORT_ID}
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD
     networks:
-      isle-internal:
+      - isle-internal
     volumes:
       - isle-db-data:/var/lib/mysql
       - ./logs/mysql:/var/log/mysql
 
   fedora:
-    image: benjaminrosner/isle-fedora:latest
+    image: islandoracollabgroup/isle-fedora:1.1
     container_name: isle-fedora-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=768M  ## Tweak to desired
+      - JAVA_MIN_MEM=128M  ## Tweak to desired
+    env_file: 
+      - tomcat.env
+      - .env
     networks:
-      isle-internal:
+      - isle-internal
     ports:
-      - "8380:8080"
+      - "8080:8080"
     depends_on:
       - mysql
       - solr
-    environment:
-      - JAVA_MAX_MEM=1G
-      - JAVA_MIN_MEM=128M
     volumes:
-      - isle-fedora-data:/usr/local/fedora/data
+      - isle-fedora-datastreamStore:/usr/local/fedora/data/datastreamStore # Migrators change this to your local DS folder.
+      - isle-fedora-objectStore:/usr/local/fedora/data/objectStore # Migrators change this to your local OS folder.
+      - isle-fedora-resourceIndex:/usr/local/fedora/data/resourceIndex # Migrators change this to your local RI folder.
+      - isle-fedora-activemq:/usr/local/fedora/data/activemq-data # Migrators change this to your local MQ folder.
+      - isle-fedora-XACML:/usr/local/fedora/data/fedora-xacml-policies
       - ./logs/fedora/fcrepo:/usr/local/fedora/server/logs
       - ./logs/fedora/tomcat:/usr/local/tomcat/logs
 
   solr:
-    image: benjaminrosner/isle-solr:latest
+    image: islandoracollabgroup/isle-solr:1.1
     container_name: isle-solr-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=512M  ## Tweak to desired
+      - JAVA_MIN_MEM=0  ## Tweak to desired
+    env_file:
+      - tomcat.env
     networks:
-      isle-internal:
+      - isle-internal
     ports:
-      - "8381:8080"
+      - "8081:8080"
     depends_on:
       - mysql
-    environment:
-      - JAVA_MAX_MEM=1G
-      - JAVA_MIN_MEM=128M
     volumes:
       - isle-solr-data:/usr/local/solr
       - ./logs/solr:/usr/local/tomcat/logs
-      
+
   image-services:
-    image: benjaminrosner/isle-imageservices:latest
+    image: islandoracollabgroup/isle-imageservices:1.1
     container_name: isle-images-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=512M
+      - JAVA_MIN_MEM=0
+    env_file: 
+      - tomcat.env
+      - .env
     networks:
-      isle-internal:
-    ports:
-      - "8382:8080"
+      - isle-internal
     depends_on:
       - apache
       - fedora
-    environment:
-      - JAVA_MAX_MEM=2G
-      - JAVA_MIN_MEM=0
+    ports:
+      - "8082:8080"
     volumes:
       - ./logs/imageservices:/usr/local/tomcat/logs
 
   apache:
-    image: benjaminrosner/isle-apache:latest
+    image: islandoracollabgroup/isle-apache:1.1
     container_name: isle-apache-${CONTAINER_SHORT_ID}
     environment:
       - PULL_ISLE_BUILD_TOOLS=true # Defaults to true.
+    env_file: 
+      - .env
     networks:
       isle-internal:
         aliases:
@@ -76,15 +90,16 @@ services:
       - mysql
       - fedora
       - solr
+      - traefik
     volumes:
       - isle-apache-data:/var/www/html
       - ./logs/apache/httpd:/var/log/apache2
       - ./logs/apache/fits:/var/log/fits
     labels:
-      - traefik.backend=isle-apache-${CONTAINER_SHORT_ID}
-      - traefik.docker.network=${ISLE_PROXY_NAME}
+      - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
       - traefik.enable=true
-      - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /fedora, /solr, /adore-djatoka, /cantaloupe, /iiif"
+      - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
+
 
 # Defined networks
 networks:
@@ -93,8 +108,13 @@ networks:
     external:
       name: ${ISLE_PROXY_NAME}
 
+# Docker controlled volumes. 
 volumes:
   isle-db-data:
-  isle-fedora-data:
+  isle-fedora-datastreamStore:
+  isle-fedora-objectStore:
+  isle-fedora-resourceIndex:
+  isle-fedora-activemq:
+  isle-fedora-XACML:
   isle-solr-data:
   isle-apache-data:

--- a/prod/tomcat.env
+++ b/prod/tomcat.env
@@ -1,0 +1,8 @@
+## Tomcat Instances (This applies to the Fedora, Solr, and ImageService containers)
+
+TOMCAT_ADMIN_USER=admin
+TOMCAT_ADMIN_PASS=isle_admin
+TOMCAT_MANAGER_USER=manager
+TOMCAT_MANAGER_PASS=isle_manager
+
+## End Tomcat

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -19,7 +19,7 @@ sleep 2
 for stack in "${STACKS[@]}"
 do
   echo "Starting work on ${stack}"
-  cd $MAIN_DIR/$stack
+  cd "$MAIN_DIR/$stack"
   echo 'Pulling images.'
   docker-compose pull
   echo 'Starting stack'

--- a/quick-stop.sh
+++ b/quick-stop.sh
@@ -9,7 +9,7 @@ MAIN_DIR=`pwd`
 for stack in "${STACKS[@]}"
 do
   echo "Removing ${stack}"
-  cd $MAIN_DIR/$stack
+  cd "$MAIN_DIR/$stack"
   docker-compose down -v
   echo "Done work on ${stack}. Moving on..."
   sleep 2

--- a/stage/.env
+++ b/stage/.env
@@ -1,40 +1,169 @@
-COMPOSE_PROJECT_NAME=isle-staging
-
+COMPOSE_PROJECT_NAME=isle-stage
 CONTAINER_SHORT_ID=stage
 
 BASE_DOMAIN=stage.isle.localdomain
 
 ISLE_PROXY_NAME=isle-proxy
 
-##################################
-## STOP EDITING!
-## THIS IS NOT YET IMPLEMENTED
-## CONFD will make magic happen.
+## Edit these to configure this instance:
 
-## Database (SQL)
+### MySQL root password
 MYSQL_ROOT_PASSWORD=ild_mysqlrt_2018
 
-## Islandora (DRUPAL)
-ADMIN_USER=isle
-ADMIN_USER_PASS=isle
-ADMIN_EMAIL=admin@isle.localdomain
-DRUPAL_SITE_NAME=ISLE.localdomain
-DRUPAL_DB=isle_ld
-DRUPAL_DB_USER=isle_ld_user
-DRUPAL_DB_PASS=isle_ld_db2018
+### Fedora database name
+FEDORA_DB=fedora3
 
-## Tomcat Instances (applies to all)
-TOMCAT_ADMIN_USER=admin
-TOMCAT_ADMIN_PASS=isle_admin
-TOMCAT_MANAGER_USER=manager
-TOMCAT_MANAGER_PASS=isle_manager
-
-## Fedora Repo
-FEDORA_ADMIN_USER=fedoraAdmin
-FEDORA_ADMIN_PASS=ild_fed_admin_2018
+### Fedora database user
 FEDORA_DB_USER=fedora_admin
+
+### Fedora database password 
 FEDORA_DB_PASS=ild_feddb_2018
 
-## Fedora GSearch
-FEDORA_GSEARCH_USER=fgsAdmin 
+### Drupal database name
+DRUPAL_DB=isle_ld 
+
+### Drupal database user
+DRUPAL_DB_USER=isle_ld_user
+
+### Drupal database password
+DRUPAL_DB_PASS=isle_ld_db2018
+
+## Database (SQL) end.
+
+
+## Islandora (DRUPAL)
+
+### Site name 
+DRUPAL_SITE_NAME=ISLE.localdomain
+
+### Site administrator user 
+DRUPAL_ADMIN_USER=isle
+
+### Site administrator password 
+DRUPAL_ADMIN_PASS=isle
+
+### Site administrator email 
+DRUPAL_ADMIN_EMAIL=admin@isle.localdomain
+
+### Hash Salt, a long unique alpha-numeric (i.e., no special characters). Suggested length greater than 40 characters. 
+DRUPAL_HASH_SALT=YO9ST25G4zaVnJT7w05PEH3r39pxhQQUf0LMo6NztY9al
+
+## End Islandora
+
+
+## Fedora Repository 
+
+### Fedora administrator user 
+FEDORA_ADMIN_USER=fedoraAdmin
+
+### Fedora administrator password 
+FEDORA_ADMIN_PASS=ild_fed_admin_2018
+
+### Fedora Generic Search user 
+FEDORA_GSEARCH_USER=fgsAdmin
+
+### Fedora Generic Search pass 
 FEDORA_GSEARCH_PASS=ild_fgs_admin_2018
+
+### Fedora internal call user 
+FEDORA_INTCALL_USER=fedoraIntCallUser
+
+### Fedora internal call password 
+FEDORA_INTCALL_PASS=ild_fed_IntCallUser_2018
+
+## End Fedora Repository
+
+
+## Image Services
+
+### Enable the Cantaloupe IIIF image service admin interface
+## Acceptable values: "true" or "false"
+CANTALOUPE_ADMIN_INTERFACE_ENABLE=true
+
+### Admin Username and Password
+CANTALOUPE_ADMIN_USER=admin
+CANTALOUPE_ADMIN_PASS=isle_admin
+
+## End Image Services
+
+
+## Database (SQL)
+
+### MySQL root password
+MYSQL_ROOT_PASSWORD=ild_mysqlrt_2018
+
+### Fedora database name
+FEDORA_DB=fedora3
+
+### Fedora database user
+FEDORA_DB_USER=fedora_admin
+
+### Fedora database password 
+FEDORA_DB_PASS=ild_feddb_2018
+
+### Drupal database name
+DRUPAL_DB=isle_ld 
+
+### Drupal database user
+DRUPAL_DB_USER=isle_ld_user
+
+### Drupal database password
+DRUPAL_DB_PASS=isle_ld_db2018
+
+## Database (SQL) end.
+
+
+## Islandora (DRUPAL)
+
+### Site name 
+DRUPAL_SITE_NAME=ISLE.localdomain
+
+### Site administrator user 
+DRUPAL_ADMIN_USER=isle
+
+### Site administrator password 
+DRUPAL_ADMIN_PASS=isle
+
+### Site administrator email 
+DRUPAL_ADMIN_EMAIL=admin@isle.localdomain
+
+### Hash Salt, a long unique alpha-numeric (i.e., no special characters). Suggested length greater than 40 characters. 
+DRUPAL_HASH_SALT=YO9ST25G4zaVnJT7w05PEH3r39pxhQQUf0LMo6NztY9al
+
+## End Islandora
+
+
+## Fedora Repository 
+
+### Fedora administrator user 
+FEDORA_ADMIN_USER=fedoraAdmin
+
+### Fedora administrator password 
+FEDORA_ADMIN_PASS=ild_fed_admin_2018
+
+### Fedora Generic Search user 
+FEDORA_GSEARCH_USER=fgsAdmin
+
+### Fedora Generic Search pass 
+FEDORA_GSEARCH_PASS=ild_fgs_admin_2018
+
+### Fedora internal call user 
+FEDORA_INTCALL_USER=fedoraIntCallUser
+
+### Fedora internal call password 
+FEDORA_INTCALL_PASS=ild_fed_IntCallUser_2018
+
+## End Fedora Repository
+
+
+## Image Services
+
+### Enable the Cantaloupe IIIF image service admin interface
+## Acceptable values: "true" or "false"
+CANTALOUPE_ADMIN_INTERFACE_ENABLE=true
+
+### Admin Username and Password
+CANTALOUPE_ADMIN_USER=admin
+CANTALOUPE_ADMIN_PASS=isle_admin
+
+## End Image Services

--- a/stage/docker-compose.yml
+++ b/stage/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       - mysql
       - fedora
       - solr
-      - traefik
     volumes:
       - isle-apache-data:/var/www/html
       - ./logs/apache/httpd:/var/log/apache2

--- a/stage/docker-compose.yml
+++ b/stage/docker-compose.yml
@@ -2,71 +2,85 @@ version: '3'
 
 services:
   mysql:
-    image: islandoracollabgroup/isle-mysql:latest
+    image: islandoracollabgroup/isle-mysql:1.1
     container_name: isle-mysql-${CONTAINER_SHORT_ID}
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD
     networks:
-      isle-internal:
+      - isle-internal
     volumes:
       - isle-db-data:/var/lib/mysql
       - ./logs/mysql:/var/log/mysql
 
   fedora:
-    image: benjaminrosner/isle-fedora:latest
+    image: islandoracollabgroup/isle-fedora:1.1
     container_name: isle-fedora-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=768M  ## Tweak to desired
+      - JAVA_MIN_MEM=128M  ## Tweak to desired
+    env_file: 
+      - tomcat.env
+      - .env
     networks:
-      isle-internal:
+      - isle-internal
     ports:
-      - "8380:8080"
+      - "8180:8080"
     depends_on:
       - mysql
       - solr
-    environment:
-      - JAVA_MAX_MEM=1G
-      - JAVA_MIN_MEM=128M
     volumes:
-      - isle-fedora-data:/usr/local/fedora/data
+      - isle-fedora-datastreamStore:/usr/local/fedora/data/datastreamStore # Migrators change this to your local DS folder.
+      - isle-fedora-objectStore:/usr/local/fedora/data/objectStore # Migrators change this to your local OS folder.
+      - isle-fedora-resourceIndex:/usr/local/fedora/data/resourceIndex # Migrators change this to your local RI folder.
+      - isle-fedora-activemq:/usr/local/fedora/data/activemq-data # Migrators change this to your local MQ folder.
+      - isle-fedora-XACML:/usr/local/fedora/data/fedora-xacml-policies
       - ./logs/fedora/fcrepo:/usr/local/fedora/server/logs
       - ./logs/fedora/tomcat:/usr/local/tomcat/logs
 
   solr:
-    image: benjaminrosner/isle-solr:latest
+    image: islandoracollabgroup/isle-solr:1.1
     container_name: isle-solr-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=512M  ## Tweak to desired
+      - JAVA_MIN_MEM=0  ## Tweak to desired
+    env_file:
+      - tomcat.env
     networks:
-      isle-internal:
+      - isle-internal
     ports:
-      - "8381:8080"
+      - "8181:8080"
     depends_on:
       - mysql
-    environment:
-      - JAVA_MAX_MEM=1G
-      - JAVA_MIN_MEM=128M
     volumes:
       - isle-solr-data:/usr/local/solr
       - ./logs/solr:/usr/local/tomcat/logs
-      
+
   image-services:
-    image: benjaminrosner/isle-imageservices:latest
+    image: islandoracollabgroup/isle-imageservices:1.1
     container_name: isle-images-${CONTAINER_SHORT_ID}
+    environment:
+      - JAVA_MAX_MEM=512M
+      - JAVA_MIN_MEM=0
+    env_file: 
+      - tomcat.env
+      - .env
     networks:
-      isle-internal:
-    ports:
-      - "8382:8080"
+      - isle-internal
     depends_on:
       - apache
       - fedora
-    environment:
-      - JAVA_MAX_MEM=2G
-      - JAVA_MIN_MEM=0
+    ports:
+      - "8182:8080"
     volumes:
       - ./logs/imageservices:/usr/local/tomcat/logs
 
   apache:
-    image: benjaminrosner/isle-apache:latest
+    image: islandoracollabgroup/isle-apache:1.1
     container_name: isle-apache-${CONTAINER_SHORT_ID}
     environment:
       - PULL_ISLE_BUILD_TOOLS=true # Defaults to true.
+    env_file: 
+      - .env
     networks:
       isle-internal:
         aliases:
@@ -76,15 +90,16 @@ services:
       - mysql
       - fedora
       - solr
+      - traefik
     volumes:
       - isle-apache-data:/var/www/html
       - ./logs/apache/httpd:/var/log/apache2
       - ./logs/apache/fits:/var/log/fits
     labels:
-      - traefik.backend=isle-apache-${CONTAINER_SHORT_ID}
-      - traefik.docker.network=${ISLE_PROXY_NAME}
+      - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
       - traefik.enable=true
-      - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /fedora, /solr, /adore-djatoka, /cantaloupe, /iiif"
+      - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
+
 
 # Defined networks
 networks:
@@ -93,8 +108,13 @@ networks:
     external:
       name: ${ISLE_PROXY_NAME}
 
+# Docker controlled volumes. 
 volumes:
   isle-db-data:
-  isle-fedora-data:
+  isle-fedora-datastreamStore:
+  isle-fedora-objectStore:
+  isle-fedora-resourceIndex:
+  isle-fedora-activemq:
+  isle-fedora-XACML:
   isle-solr-data:
   isle-apache-data:

--- a/stage/tomcat.env
+++ b/stage/tomcat.env
@@ -1,0 +1,8 @@
+## Tomcat Instances (This applies to the Fedora, Solr, and ImageService containers)
+
+TOMCAT_ADMIN_USER=admin
+TOMCAT_ADMIN_PASS=isle_admin
+TOMCAT_MANAGER_USER=manager
+TOMCAT_MANAGER_PASS=isle_manager
+
+## End Tomcat


### PR DESCRIPTION
This PR updates a number of important things:

Docker-composes are now on ISLE v1.1 with the following updates:
- minor port changes: PROD now sits on 8080, 8081, 8082; STAGE: 8180, 8182, 8183; DEV: 8280, 8281, 8282 (it make sense at the time.)
- **.env files are now parsed and important**
- no longer pulling deprecated stack from development repo!

Update the quick start and quick stop scripts:
- added quotes for bash variable expansion

Users are advised to update each .env with at least a unique site name, the rest, if you're testing, is fine.